### PR TITLE
Bump versions to avoid Node 12 deprecation

### DIFF
--- a/.github/workflows/Selenium-Action_Template.yaml
+++ b/.github/workflows/Selenium-Action_Template.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setting up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - name: Installing package list


### PR DESCRIPTION
Running using actions/checkout@v2, actions/setup-python@v2 gives the following deprecation warning:

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.