### PR TITLE
bump versions ✏️

### DIFF
--- a/.github/workflows/Selenium-Action_Template.yaml
+++ b/.github/workflows/Selenium-Action_Template.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setting up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Installing package list


### PR DESCRIPTION
Bumped version to avoid Node deprecation error, as discussed [here](https://github.com/MarketingPipeline/Python-Selenium-Action/pull/5)